### PR TITLE
Add doctest module configuration for doctests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PiccoloDocsTemplate"
 uuid = "a90a139f-c522-4b23-980b-4210ddb8d065"
 authors = ["Gennadi Ryan <gennadiryan@gmail.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -55,7 +55,7 @@ function generate_docs(
     format_kwargs=NamedTuple(),
     makedocs_kwargs=NamedTuple(),
     deploydocs_kwargs=NamedTuple(),
-    doctest_setup_meta_args::Dict{Module, Symbol} = Dict{Module, Symbol}(),
+    doctest_setup_meta_args::Dict{Module, Expr} = Dict{Module, Expr}(),
 )
     @info "Building Documenter site for " * package_name * ".jl"
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -55,6 +55,7 @@ function generate_docs(
     format_kwargs=NamedTuple(),
     makedocs_kwargs=NamedTuple(),
     deploydocs_kwargs=NamedTuple(),
+    doctest_setup_meta_args::Dict{Module, Symbol} = Dict{Module, Symbol}(),
 )
     @info "Building Documenter site for " * package_name * ".jl"
 
@@ -97,6 +98,13 @@ function generate_docs(
         )),
         format_kwargs...,
     )
+
+    # for each mod in modules, make a call to DocMeta.setdocmeta!(module, :DocTestSetup, doctest_setup_meta_args; recursive=true)
+    for mod in modules
+        if haskey(doctest_setup_meta_args, mod)
+            DocMeta.setdocmeta!(mod, :DocTestSetup, doctest_setup_meta_args[mod]; recursive=true)
+        end
+    end
 
     makedocs(;
         modules=modules,


### PR DESCRIPTION
The doctests inside of doc strings require the module to have its doc metadata set. Since documenter 0.23, the meta blocks in markdown files do not affect the doctests in docstrings

See https://documenter.juliadocs.org/stable/man/doctests/#DocTestSetup-and-DocTestTeardown-in-@meta-blocks

see also https://github.com/harmoniqs/TrajectoryIndexingUtils.jl/pull/8 for usage