### PR TITLE
add draft_pages preprocessing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PiccoloDocsTemplate"
 uuid = "a90a139f-c522-4b23-980b-4210ddb8d065"
 authors = ["Gennadi Ryan <gennadiryan@gmail.com>"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,9 +5,9 @@ using Literate
 
 function add_draft_to_meta(str::String)
     draft_meta_string = """
-    ```@meta
-    Draft = true
-    ```
+    # ```@meta
+    # Draft = true
+    # ```
 
     """
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -89,7 +89,7 @@ function generate_docs(
     make_index=true,
     make_literate=true,
     make_assets=true,
-    draft_pages::Vector=nothing,    # must be a subset of the intersection of literate pages and the pages vector.
+    literate_draft_pages::Vector=nothing,    # must be a subset of literate pages inside of `src/literate`
     repo="github.com/harmoniqs/" * package_name * ".jl.git",
     versions=["dev" => "dev", "stable" => "v^", "v#.#"],
     format_kwargs=NamedTuple(),
@@ -108,7 +108,7 @@ function generate_docs(
     end
 
     if make_literate
-        generate_literate(root, draft_pages = draft_pages)
+        generate_literate(root, draft_pages = literate_draft_pages)
     end
 
     if make_assets

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -89,7 +89,7 @@ function generate_docs(
     make_index=true,
     make_literate=true,
     make_assets=true,
-    draft_pages::Vector=nothing,    # must be a subset of pages vector
+    draft_pages::Vector=nothing,    # must be a subset of the intersection of literate pages and the pages vector.
     repo="github.com/harmoniqs/" * package_name * ".jl.git",
     versions=["dev" => "dev", "stable" => "v^", "v#.#"],
     format_kwargs=NamedTuple(),
@@ -138,12 +138,6 @@ function generate_docs(
         )),
         format_kwargs...,
     )
-
-    for draft_page in draft_pages
-        if draft_page in pages
-            DocMeta.setdocmeta!()
-        end
-    end
 
     # for each mod in modules, make a call to DocMeta.setdocmeta!(module, :DocTestSetup, doctest_setup_meta_args; recursive=true)
     for mod in modules

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -108,7 +108,7 @@ function generate_docs(
     end
 
     if make_literate
-        generate_literate(root, draft_pages)
+        generate_literate(root, draft_pages = draft_pages)
     end
 
     if make_assets


### PR DESCRIPTION
this pr adds the ability to pass in a list of pages that can be marked draft (using the literate pre-processor).

This only applies to literate pages as those pages are the only ones we want to ensure successful execution on each time we build the docs and provide examples.