### PR TITLE
Fix versioned docs not deploying from TagBot triggers

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -157,6 +157,13 @@ function generate_docs(
         makedocs_kwargs...,
     )
 
+    # Documenter.jl only deploys for push, workflow_dispatch, or schedule events.
+    # TagBot triggers docs via repository_dispatch, which Documenter rejects.
+    # Override the event name so versioned docs actually deploy.
+    if get(ENV, "GITHUB_EVENT_NAME", "") == "repository_dispatch"
+        ENV["GITHUB_EVENT_NAME"] = "push"
+    end
+
     deploydocs(;
         repo=repo,
         devbranch="main",


### PR DESCRIPTION
## Summary
- Documenter.jl only accepts `push`, `workflow_dispatch`, or `schedule` as valid `GITHUB_EVENT_NAME` values for deployment
- TagBot triggers docs builds via `repository_dispatch`, which Documenter silently rejects
- This caused versioned docs to never deploy for tagged releases across all repos using this template (Piccolo.jl, DirectTrajOpt.jl, NamedTrajectories.jl, TrajectoryIndexingUtils.jl)
- Fix: override `GITHUB_EVENT_NAME` to `"push"` when running under `repository_dispatch`

## Impact
After merging and releasing, repos that bump their `DOC_TEMPLATE_VERSION` will start deploying versioned docs again. Currently missing versions:

| Repo | Latest Tag | Latest Versioned Docs |
|------|-----------|----------------------|
| Piccolo.jl | v1.0.0 | v0.8 |
| DirectTrajOpt.jl | v0.8.1 | v0.4 |
| NamedTrajectories.jl | v0.8.2 | v0.5 |