### PR TITLE
Use Documenter.except for smart warnonly error handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PiccoloDocsTemplate"
 uuid = "a90a139f-c522-4b23-980b-4210ddb8d065"
 authors = ["Gennadi Ryan <gennadiryan@gmail.com>"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -218,7 +218,14 @@ function generate_docs(
         format = format,
         pages = pages,
         pagesonly = true,
-        warnonly = true,
+        warnonly = Documenter.except(
+            :eval_block,
+            :example_block,
+            :setup_block,
+            :parse_error,
+            :doctest,
+            :cross_references,
+        ),
         draft = false,
         makedocs_kwargs...,
     )


### PR DESCRIPTION
## Summary
- Replaces `warnonly = true` with `Documenter.except(...)` to fail the build on meaningful errors
- Build-failing: `:eval_block`, `:example_block`, `:setup_block`, `:parse_error`, `:doctest`, `:cross_references`
- Warn-only: `:autodocs_block`, `:docs_block`, `:meta_block`, `:missing_docs`, `:footnote`, `:linkcheck`, `:linkcheck_remotes`