### PR TITLE
feat: add generate_contributing for CONTRIBUTING.md → docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PiccoloDocsTemplate"
 uuid = "a90a139f-c522-4b23-980b-4210ddb8d065"
 authors = ["Gennadi Ryan <gennadiryan@gmail.com>"]
-version = "0.7.1"
+version = "0.8.0"
 
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -87,6 +87,16 @@ function generate_assets(root::String)
     cp(assets, assets_output, force = true)
 end
 
+function generate_contributing(root::String)
+    src = normpath(joinpath(root, "src"))
+    contributing = normpath(joinpath(root, "..", "CONTRIBUTING.md"))
+
+    contributing_output = joinpath(src, "development", "contributing.md")
+    mkpath(dirname(contributing_output))
+
+    cp(contributing, contributing_output, force = true)
+end
+
 
 """
     _mask_cached_solve!(build_dir)
@@ -146,6 +156,7 @@ function generate_docs(
     make_index = true,
     make_literate = true,
     make_assets = true,
+    make_contributing = false,
     literate_draft_pages::Vector = String[],    # must be a subset of literate pages inside of `src/literate`
     literate_kwargs::NamedTuple = NamedTuple(),    # kwargs passed to Literate.markdown (e.g. execute=false)
     repo = "github.com/harmoniqs/" * package_name * ".jl.git",
@@ -176,6 +187,10 @@ function generate_docs(
 
     if make_assets
         generate_assets(root)
+    end
+
+    if make_contributing
+        generate_contributing(root)
     end
 
     format = Documenter.HTML(;


### PR DESCRIPTION
## Summary

Mirrors the existing `generate_index` / `generate_assets` pattern: copies the root `CONTRIBUTING.md` into `src/development/contributing.md` so downstream packages can keep a single source of truth at the repo root without inlining `cp()` calls in their `docs/make.jl`.

Gated behind a new `make_contributing` kwarg on `generate_docs` (default `false`, opt-in).

Bumps to v0.8.0. Once merged, tag `v0.8.0` so consumers can pin via `DOC_TEMPLATE_VERSION` in their `docs.yml`.

## Test plan
- [ ] Will be exercised by harmoniqs/Piccolo.jl#65 once this is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)